### PR TITLE
Small README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 [![PyPI version](https://badge.fury.io/py/django-gamification.svg)](https://badge.fury.io/py/django-gamification)
 [![Build Status](https://travis-ci.org/mattjegan/django-gamification.svg?branch=master)](https://travis-ci.org/mattjegan/django-gamification)
 
-Django Gamification aims to fill the gamification sized whole in the Django package ecosystem. In the current state, Django Gamification provides a set of models that can be used to implement gamification features in your application. These include a centralised interface for keeping track of all gamification related objects including badges, points, and unlockables.
+Django Gamification aims to fill the gamification sized hole in the Django package ecosystem. In the current state, Django Gamification provides a set of models that can be used to implement gamification features in your application. These include a centralised interface for keeping track of all gamification related objects including badges, points, and unlockables.
 
 ## Installation
 
-Download from PyPi:
+Download from PyPI:
 ```
-pip install django_gamification
+pip install django-gamification
 ```
 
 And add to your `INSTALLED_APPS`:


### PR DESCRIPTION
* 'hole' not 'whole' 😉
* pip normalizes `_` to `-` so `pip install django-gamification` is the actual command

N.B. the README doesn't render on the PyPI page because it's markdown and only reStructuredText is supported, you might consider converting it.